### PR TITLE
Allowed loops in LuaController, fixed certain strings

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -385,14 +385,13 @@ local function lexLua(code)
         local inEscape=true
         local rstr=""
         for i=1,str:len() do
-            local c=str:sub(1,1)
+            local c=str:sub(i,i)
+            rstr=rstr..c
             if inEscape then
-                rstr=rstr..c
                 inEscape=false
             else
-                if c==quoteType then return rstr..quoteType end
+                if c==quoteType then return rstr end
                 if c=="\\" then inEscape=true end
-                rstr=rstr..c
             end
         end
         return nil --unfinished string

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -1,8 +1,8 @@
---		______
---	   |
---	   |
---	   |		__	   ___  _   __		 _  _
--- |   | |	   |  | |\ |  |  |_| |  | |  |  |_ |_|
+--        ______
+--       |
+--       |
+--       |        __       ___  _   __         _  _
+-- |   | |       |  | |\ |  |  |_| |  | |  |  |_ |_|
 -- |___| |______ |__| | \|  |  | \ |__| |_ |_ |_ |\
 -- |
 -- |
@@ -55,7 +55,7 @@ local function update_real_port_states(pos, rule_name, new_state)
 		L[i] = n % 2
 		n = math.floor(n / 2)
 	end
-	--				   (0,-1) (-1,0)	  (1,0) (0,1)
+	--                   (0,-1) (-1,0)      (1,0) (0,1)
 	local pos_to_side = {  4,	 1,   nil,   3,	2 }
 	if rule_name.x == nil then
 		for _, rname in ipairs(rule_name) do

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -398,14 +398,14 @@ local function lexLua(code)
         return nil --unfinished string
     end
     function lexElements.blockcomment(str)
-        local a=str:match("^--%[%[")
+        local a=str:match("^%-%-%[%[")
         if not a then return nil end
-        local s=str:find("--%]%]")
+        local s=str:find("%-%-%]%]")
         if not s then return nil end
         return str:sub(1,s+3)
     end
     function lexElements.linecomment(str)
-        return str:match("^--[^\r\n]+")
+        return str:match("^%-%-[^\r\n]+")
     end
     local lexElementsOrder={"keyword","whitespace","string","blockcomment","linecomment","cleanup"}
     local lexResults={}
@@ -470,6 +470,7 @@ local function code_prohibited(code)
         end
         rcode=rcode..v[2]
     end
+    print(rcode)
     return rcode
 end
 

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -341,18 +341,6 @@ local function create_environment(pos, mem, event)
         return unpack(pcr)
     end
     
-    --Only input differs-this wrapper exists to catch certain outputs that shouldn't be caught by a (x)pcall
-    
-    env.xpcall=function(...)
-        local pcr={xpcall(...)}
-        if not pcr[1] then
-            if pcr[2]~=timeout_error then
-                error(pcr[2])
-            end
-        end
-        return unpack(pcr)
-    end
-
 	return env
 end
 

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -470,7 +470,6 @@ local function code_prohibited(code)
         end
         rcode=rcode..v[2]
     end
-    print(rcode)
     return rcode
 end
 


### PR DESCRIPTION
Currently, the LuaController doesn't allow using loops, despite there being code to handle a infinite loop.
This is because LuaJIT doesn't call debug hooks on empty loops.
So, this commit adds code into loops, to ensure the debug hooks are called.
Furthermore, this fixes the bug where strings containing " while " or " do " or similar would cause a error, by adding a lexer to identify strings and comments, then ignore them.
Finally, it fixes a potential server-crasher involving pcall and xpcall.