### PR TITLE
Don't refer to LIGHT_MAX global; use default.

### DIFF
--- a/mesecons/oldwires.lua
+++ b/mesecons/oldwires.lua
@@ -30,7 +30,7 @@ minetest.register_node("mesecons:mesecon_on", {
 	},
 	groups = {dig_immediate=3, not_in_creaive_inventory=1, mesecon=1},
 	drop = "mesecons:mesecon_off 1",
-	light_source = LIGHT_MAX-11,
+	light_source = default.LIGHT_MAX-11,
 	mesecons = {conductor={
 		state = mesecon.state.on,
 		offstate = "mesecons:mesecon_off"

--- a/mesecons_button/init.lua
+++ b/mesecons_button/init.lua
@@ -67,7 +67,7 @@ minetest.register_node("mesecons_button:button_on", {
 	paramtype2 = "facedir",
 	legacy_wallmounted = true,
 	walkable = false,
-	light_source = LIGHT_MAX-7,
+	light_source = default.LIGHT_MAX-7,
 	sunlight_propagates = true,
 	selection_box = {
 		type = "fixed",

--- a/mesecons_lamp/init.lua
+++ b/mesecons_lamp/init.lua
@@ -17,7 +17,7 @@ minetest.register_node("mesecons_lamp:lamp_on", {
 	legacy_wallmounted = true,
 	sunlight_propagates = true,
 	walkable = true,
-	light_source = LIGHT_MAX,
+	light_source = default.LIGHT_MAX,
 	node_box = mesecon_lamp_box,
 	selection_box = mesecon_lamp_box,
 	groups = {dig_immediate=3,not_in_creative_inventory=1, mesecon_effector_on = 1},

--- a/mesecons_lightstone/init.lua
+++ b/mesecons_lightstone/init.lua
@@ -31,7 +31,7 @@ function mesecon.lightstone_add(name, base_item, texture_off, texture_on)
 	tiles = {texture_on},
 	groups = {cracky=2,not_in_creative_inventory=1, mesecon = 2},
 	drop = "mesecons_lightstone:lightstone_" .. name .. "_off",
-	light_source = LIGHT_MAX-2,
+	light_source = default.LIGHT_MAX-2,
 	sounds = default.node_sound_stone_defaults(),
 	mesecons = {effector = {
 		rules = lightstone_rules,

--- a/mesecons_powerplant/init.lua
+++ b/mesecons_powerplant/init.lua
@@ -9,7 +9,7 @@ minetest.register_node("mesecons_powerplant:power_plant", {
 	paramtype = "light",
 	walkable = false,
 	groups = {dig_immediate=3, mesecon = 2},
-	light_source = LIGHT_MAX-9,
+	light_source = default.LIGHT_MAX-9,
     	description="Power Plant",
 	selection_box = {
 		type = "fixed",

--- a/mesecons_torch/init.lua
+++ b/mesecons_torch/init.lua
@@ -76,7 +76,7 @@ minetest.register_node("mesecons_torch:mesecon_torch_on", {
 	paramtype2 = "wallmounted",
 	selection_box = torch_selectionbox,
 	groups = {dig_immediate=3},
-	light_source = LIGHT_MAX-5,
+	light_source = default.LIGHT_MAX-5,
 	description="Mesecon Torch",
 	mesecons = {receptor = {
 		state = mesecon.state.on,


### PR DESCRIPTION
The LIGHT_MAX global is created in the legacy.lua file in the default
mod; it states that it's there for backwards compatibility, but it would
be better to reference the proper value inside the default table.