### PR TITLE
Use right mouse button instead of left to press button and change state of switch and lever.

### DIFF
--- a/mesecons_button/init.lua
+++ b/mesecons_button/init.lua
@@ -40,7 +40,7 @@ minetest.register_node("mesecons_button:button_off", {
 	},
 	groups = {dig_immediate=2, mesecon_needs_receiver = 1},
 	description = "Button",
-	on_punch = function (pos, node)
+	on_rightclick = function (pos, node)
 		minetest.swap_node(pos, {name = "mesecons_button:button_on", param2=node.param2})
 		mesecon.receptor_on(pos, mesecon.rules.buttonlike_get(node))
 		minetest.sound_play("mesecons_button_push", {pos=pos})

--- a/mesecons_switch/init.lua
+++ b/mesecons_switch/init.lua
@@ -4,7 +4,7 @@ mesecon.register_node("mesecons_switch:mesecon_switch", {
 	paramtype2="facedir",
 	description="Switch",
 	sounds = default.node_sound_stone_defaults(),
-	on_punch = function (pos, node)
+	on_rightclick = function (pos, node)
 		if(mesecon.flipstate(pos, node) == "on") then
 			mesecon.receptor_on(pos)
 		else

--- a/mesecons_walllever/init.lua
+++ b/mesecons_walllever/init.lua
@@ -15,7 +15,7 @@ mesecon.register_node("mesecons_walllever:wall_lever", {
 		fixed = { -8/16, -8/16, 3/16, 8/16, 8/16, 8/16 },
 	},
 	sounds = default.node_sound_wood_defaults(),
-	on_punch = function (pos, node)
+	on_rightclick = function (pos, node)
 		if(mesecon.flipstate(pos, node) == "on") then
 			mesecon.receptor_on(pos, mesecon.rules.buttonlike_get(node))
 		else


### PR DESCRIPTION
The left mouse button is used to press button and change state of switch and lever while the same button is used to dig nodes, which makes bad composition especially when we want to pickup levers and button without firing them. However, the right button isn't used for anything. Why not to use it then?