### PR TITLE
fix door compatibility

### DIFF
--- a/mesecons_doors/init.lua
+++ b/mesecons_doors/init.lua
@@ -52,13 +52,13 @@ local function meseconify_door(name)
 				action_on = function(pos, node)
 					local door = doors.get(pos)
 					if door then
-						door:open()
+						door:toggle()
 					end
 				end,
 				action_off = function(pos, node)
 					local door = doors.get(pos)
 					if door then
-						door:close()
+						door:toggle()
 					end
 				end,
 				rules = mesecon.rules.pplate
@@ -95,13 +95,13 @@ if doors and doors.get then
 			action_on = function(pos, node)
 				local door = doors.get(pos)
 				if door then
-					door:open()
+					door:toggle()
 				end
 			end,
 			action_off = function(pos, node)
 				local door = doors.get(pos)
 				if door then
-					door:close()
+					door:toggle()
 				end
 			end,
 		}},


### PR DESCRIPTION
toggle doors instead of opening and closing them, fixes solar panel flowers

![screenshot_20160227_114443](https://cloud.githubusercontent.com/assets/3192173/13372548/d1b5a4b8-dd47-11e5-9493-683408df2ae4.png)

doors can be placed in a way that closing them means opening them, mesecons supported this, by closing and opening doors instead of toggling them, lots of automatically opening doors get broken, and if this gets merged, breaking those is stopped