### PR TITLE
Remove 'do' and add 'function'.

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -350,7 +350,7 @@ local function code_prohibited(code)
 	if not jit then
 		return false
 	end
-	local prohibited = {"while", "for", "do", "repeat", "until", "goto"}
+	local prohibited = {"while", "for", "repeat", "until", "goto", "function"}
 	code = " "..code.." "
 	for _, p in ipairs(prohibited) do
 		if string.find(code, "[^%w_]"..p.."[^%w_]") then


### PR DESCRIPTION
'do' is not a looping construct, and is useful for restricting scope context, as in
  local a = 2
  do
    local a = 3
  end
  -- a is 2 here
or to force early return (usually when debugging) as in
  do
    return
  end

'function' can be used to crash the server by making a function recursive or tail-recursive, as in

  function x()
    x()
  end