### PR TITLE
fix `remove_functions` stack overflow bug

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -229,23 +229,36 @@ end
 
 local function remove_functions(x)
 	local tp = type(x)
-	if tp == "table" then
-		for key, value in pairs(x) do
-			local key_t, val_t = type(key), type(value)
-			if key_t == "function" or val_t == "function" then
-				x[key] = nil
-			else
-				if key_t == "table" then
-					remove_functions(key)
-				end
-				if val_t == "table" then
-					remove_functions(value)
+	if tp == "function" then
+		return nil
+	end
+
+	local seen = {}
+
+	local function rfuncs(x)
+		if seen[x] then return end
+		seen[x] = true
+
+		local tp = type(x)
+		if tp == "table" then
+			for key, value in pairs(x) do
+				local key_t, val_t = type(key), type(value)
+				if key_t == "function" or val_t == "function" then
+					x[key] = nil
+				else
+					if key_t == "table" then
+						rfuncs(key)
+					end
+					if val_t == "table" then
+						rfuncs(value)
+					end
 				end
 			end
 		end
-	elseif tp == "function" then
-		return nil
 	end
+
+	rfuncs(x)
+
 	return x
 end
 


### PR DESCRIPTION
This fixes #262.

I added a `local function rfuncs(x)` inside of `remove_functions` that does what `remove_functions` used to do, but then I made `rfuncs(x)` first see if `seen[x]` is `true` and return if it is, and then set `seen[x] = true`, and then go on to do what `remove_functions` used to do.

Then, I made `remove_functions` declare a `local seen = {}` that becomes an upvalue of `rfuncs`, then call `rfuncs(x)`, and then finally return `x`, which now has all of its functions removed.  