### PR TITLE
Spitted a string on two lines

### DIFF
--- a/mesecons_commandblock/init.lua
+++ b/mesecons_commandblock/init.lua
@@ -47,7 +47,7 @@ local function initialize_data(meta)
 	meta:set_string("formspec",
 		"invsize[9,5;]" ..
 		"textarea[0.5,0.5;8.5,4;commands;Commands;"..commands.."]" ..
-		"label[1,3.8;@nearest, @farthest, and @random are replaced by the respective player names]" ..
+		"label[1,3.8;@nearest, @farthest, and @random are replaced by\nthe respective player names]" ..
 		"button_exit[3.3,4.5;2,1;submit;Submit]")
 	local owner = meta:get_string("owner")
 	if owner == "" then


### PR DESCRIPTION
Cosmetic - prevents the line from going out of the configuration window