### PR TITLE
Don't bother checking if a node can overheat before cooling it

### DIFF
--- a/mesecons/services.lua
+++ b/mesecons/services.lua
@@ -87,10 +87,6 @@ end
 
 
 mesecon.queue:add_function("cooldown", function (pos)
-	if minetest.get_item_group(minetest.get_node(pos).name, "overheat") == 0 then
-		return -- node has been moved, this one does not use overheating - ignore
-	end
-
 	local meta = minetest.get_meta(pos)
 	local heat = meta:get_int("heat")
 


### PR DESCRIPTION
This might /seem/ backwards, but the check is *very* expensive time-wise (as much as 30% of the total lag in the world I tested it with), and not entirely necessary since meta:get_int("heat") returns 0 if called on a meta that doesn't contain "heat".

I did test it quite thoroughly as well, and Nothing Bad Happened(TM).