### PR TITLE
Use a VoxelManipulator to load unloaded areas

### DIFF
--- a/mesecons/init.lua
+++ b/mesecons/init.lua
@@ -70,6 +70,8 @@ dofile(minetest.get_modpath("mesecons").."/internal.lua");
 -- these are the only functions you need to remember
 
 mesecon.queue:add_function("receptor_on", function (pos, rules)
+	mesecon.vm_begin()
+
 	rules = rules or mesecon.rules.default
 
 	-- if area (any of the rule targets) is not loaded, keep trying and call this again later
@@ -90,6 +92,8 @@ mesecon.queue:add_function("receptor_on", function (pos, rules)
 			mesecon.turnon(np, rulename)
 		end
 	end
+
+	mesecon.vm_commit()
 end)
 
 function mesecon.receptor_on(pos, rules)
@@ -97,6 +101,8 @@ function mesecon.receptor_on(pos, rules)
 end
 
 mesecon.queue:add_function("receptor_off", function (pos, rules)
+	mesecon.vm_begin()
+
 	rules = rules or mesecon.rules.default
 
 	-- if area (any of the rule targets) is not loaded, keep trying and call this again later
@@ -119,6 +125,8 @@ mesecon.queue:add_function("receptor_off", function (pos, rules)
 			end
 		end
 	end
+
+	mesecon.vm_commit()
 end)
 
 function mesecon.receptor_off(pos, rules)

--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -379,42 +379,25 @@ function mesecon.turnon(pos, link)
 		local f = frontiers[depth]
 		local node = mesecon.get_node_force(f.pos)
 
-		-- area not loaded, postpone action
 		if not node then
-			mesecon.queue:add_action(f.pos, "turnon", {f.link}, nil, true)
+			-- Area does not exist; do nothing
 		elseif mesecon.is_conductor_off(node, f.link) then
 			local rules = mesecon.conductor_get_rules(node)
-
-			-- Success: If false, at least one neighboring node is unloaded,
-			-- postpone turning on action
-			local success = true
 			local neighborlinks = {}
 
 			-- call turnon on neighbors
 			for _, r in ipairs(mesecon.rule2meta(f.link, rules)) do
 				local np = vector.add(f.pos, r)
-
-				-- Neighboring node not loaded, postpone turning on current node
-				-- since we can't even know if neighboring node has matching rules
-				if not mesecon.get_node_force(np) then
-					success = false
-					break
-				else
-					neighborlinks[minetest.hash_node_position(np)] = mesecon.rules_link_rule_all(f.pos, r)
-				end
+				neighborlinks[minetest.hash_node_position(np)] = mesecon.rules_link_rule_all(f.pos, r)
 			end
 
-			if success then
-				mesecon.swap_node_force(f.pos, mesecon.get_conductor_on(node, f.link))
+			mesecon.swap_node_force(f.pos, mesecon.get_conductor_on(node, f.link))
 
-				for npos, links in pairs(neighborlinks) do
-					-- links = all links to node, l = each single link
-					for _, l in ipairs(links) do
-						table.insert(frontiers, {pos = minetest.get_position_from_hash(npos), link = l})
-					end
+			for npos, links in pairs(neighborlinks) do
+				-- links = all links to node, l = each single link
+				for _, l in ipairs(links) do
+					table.insert(frontiers, {pos = minetest.get_position_from_hash(npos), link = l})
 				end
-			else
-				mesecon.queue:add_action(f.pos, "turnon", {f.link}, nil, true)
 			end
 		elseif mesecon.is_effector(node.name) then
 			mesecon.changesignal(f.pos, node, f.link, mesecon.state.on, depth)
@@ -440,40 +423,24 @@ function mesecon.turnoff(pos, link)
 
 		-- area not loaded, postpone action
 		if not node then
-			mesecon.queue:add_action(f.pos, "turnoff", {f.link}, nil, true)
+			-- Area does not exist; do nothing
 		elseif mesecon.is_conductor_on(node, f.link) then
 			local rules = mesecon.conductor_get_rules(node)
-
-			-- Success: If false, at least one neighboring node is unloaded,
-			-- postpone turning on action
-			local success = true
 			local neighborlinks = {}
 
 			-- call turnoff on neighbors
 			for _, r in ipairs(mesecon.rule2meta(f.link, rules)) do
 				local np = vector.add(f.pos, r)
-
-				-- Neighboring node not loaded, postpone turning off current node
-				-- since we can't even know if neighboring node has matching rules
-				if not mesecon.get_node_force(np) then
-					success = false
-					break
-				else
-					neighborlinks[minetest.hash_node_position(np)] = mesecon.rules_link_rule_all(f.pos, r)
-				end
+				neighborlinks[minetest.hash_node_position(np)] = mesecon.rules_link_rule_all(f.pos, r)
 			end
 
-			if success then
-				mesecon.swap_node_force(f.pos, mesecon.get_conductor_off(node, f.link))
+			mesecon.swap_node_force(f.pos, mesecon.get_conductor_off(node, f.link))
 
-				for npos, links in pairs(neighborlinks) do
-					-- links = all links to node, l = each single link
-					for _, l in ipairs(links) do
-						table.insert(frontiers, {pos = minetest.get_position_from_hash(npos), link = l})
-					end
+			for npos, links in pairs(neighborlinks) do
+				-- links = all links to node, l = each single link
+				for _, l in ipairs(links) do
+					table.insert(frontiers, {pos = minetest.get_position_from_hash(npos), link = l})
 				end
-			else
-				mesecon.queue:add_action(f.pos, "turnoff", {f.link}, nil, true)
 			end
 		elseif mesecon.is_effector(node.name) then
 			mesecon.changesignal(f.pos, node, f.link, mesecon.state.off, depth)

--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -405,8 +405,7 @@ function mesecon.turnon(pos, link)
 			end
 
 			if success then
-				minetest.swap_node(f.pos, {name = mesecon.get_conductor_on(node, f.link),
-					param2 = node.param2})
+				mesecon.swap_node_force(f.pos, mesecon.get_conductor_on(node, f.link))
 
 				for npos, links in pairs(neighborlinks) do
 					-- links = all links to node, l = each single link
@@ -465,8 +464,7 @@ function mesecon.turnoff(pos, link)
 			end
 
 			if success then
-				minetest.swap_node(f.pos, {name = mesecon.get_conductor_off(node, f.link),
-					param2 = node.param2})
+				mesecon.swap_node_force(f.pos, mesecon.get_conductor_off(node, f.link))
 
 				for npos, links in pairs(neighborlinks) do
 					-- links = all links to node, l = each single link


### PR DESCRIPTION
This is a proof of concept of my simplest proposal on GH-277, using the VoxelManipulator to prime the mapblock cache when `get_node_or_nil` fails rather than using forceloading to keep all needed mapblocks in cache at all times.