### PR TITLE
Remove an obsolete comment.

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -20,8 +20,6 @@
 -- The Sandbox
 -- The whole code of the controller runs in a sandbox,
 -- a very restricted environment.
--- However, as this does not prevent you from using e.g. loops,
--- we need to check for these prohibited commands first.
 -- Actually the only way to damage the server is to
 -- use too much memory from the sandbox.
 -- You can add more functions to the environment


### PR DESCRIPTION
I think these two comment lines are left over from when the LuaController did some string scanning to look for forbidden text. It no longer does this, relying entirely on the debug subsystem to prevent taking too much time.