### PR TITLE
Cache forceload_timeout setting

### DIFF
--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -255,9 +255,10 @@ function mesecon.get_node_force(pos)
 end
 
 minetest.register_globalstep(function (dtime)
+	local timeout = mesecon.setting("forceload_timeout", 600)
 	for hash, time in pairs(mesecon.forceloaded_blocks) do
 		-- unload forceloaded blocks after 10 minutes without usage
-		if (time > mesecon.setting("forceload_timeout", 600)) then
+		if (time > timeout) then
 			minetest.forceload_free_block(unhash_blockpos(hash))
 			mesecon.forceloaded_blocks[hash] = nil
 		else


### PR DESCRIPTION
While I was experimenting with the profiler on a local copy of VanessaE's creative server (which is quite mesecons-heavy), I noticed that this globalstep function was taking quite a long time to run. This change brought it from about 20% of the globalstep time down to about 5%.
