### PR TITLE
Remove an unused function.

### DIFF
--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -231,11 +231,6 @@ local function hash_blockpos(pos)
 	})
 end
 
--- convert block hash --> node position
-local function unhash_blockpos(hash)
-	return vector.multiply(minetest.get_position_from_hash(hash), BLOCKSIZE)
-end
-
 -- Maps from a hashed mapblock position (as returned by hash_blockpos) to a
 -- table.
 --


### PR DESCRIPTION
The unhash_blockpos function used to be used in util.lua, but now it is only used in legacy.lua. The one in util.lua can be deleted.