### PR TITLE
Properly handle rotation of buttons/levers

### DIFF
--- a/mesecons/presets.lua
+++ b/mesecons/presets.lua
@@ -41,12 +41,19 @@ mesecon.rules.alldirs =
 
 mesecon.rules.buttonlike_get = function(node)
 	local rules = mesecon.rules.buttonlike
-	if node.param2 == 2 then
+	local dir = minetest.facedir_to_dir(node.param2)
+	if dir.x == 1 then
+		-- No action needed
+	elseif dir.z == -1 then
 		rules=mesecon.rotate_rules_left(rules)
-	elseif node.param2 == 3 then
+	elseif dir.x == -1 then
 		rules=mesecon.rotate_rules_right(mesecon.rotate_rules_right(rules))
-	elseif node.param2 == 0 then
+	elseif dir.z == 1 then
 		rules=mesecon.rotate_rules_right(rules)
+	elseif dir.y == -1 then
+		rules=mesecon.rotate_rules_up(rules)
+	elseif dir.y == 1 then
+		rules=mesecon.rotate_rules_down(rules)
 	end
 	return rules
 end

--- a/mesecons_button/init.lua
+++ b/mesecons_button/init.lua
@@ -26,6 +26,7 @@ minetest.register_node("mesecons_button:button_off", {
 	paramtype2 = "facedir",
 	legacy_wallmounted = true,
 	walkable = false,
+	on_rotate = mesecon.buttonlike_onrotate,
 	sunlight_propagates = true,
 	selection_box = {
 	type = "fixed",
@@ -67,6 +68,7 @@ minetest.register_node("mesecons_button:button_on", {
 	paramtype2 = "facedir",
 	legacy_wallmounted = true,
 	walkable = false,
+	on_rotate = false,
 	light_source = default.LIGHT_MAX-7,
 	sunlight_propagates = true,
 	selection_box = {

--- a/mesecons_receiver/init.lua
+++ b/mesecons_receiver/init.lua
@@ -28,16 +28,8 @@ local receiver_get_rules = function (node)
 	return rules
 end
 
-minetest.register_node("mesecons_receiver:receiver_on", {
+mesecon.register_node("mesecons_receiver:receiver", {
 	drawtype = "nodebox",
-	tiles = {
-		"receiver_top_on.png",
-		"receiver_bottom_on.png",
-		"receiver_lr_on.png",
-		"receiver_lr_on.png",
-		"receiver_fb_on.png",
-		"receiver_fb_on.png",
-	},
 	paramtype = "light",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
@@ -52,17 +44,8 @@ minetest.register_node("mesecons_receiver:receiver_on", {
 	},
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
-	mesecons = {conductor = {
-		state = mesecon.state.on,
-		rules = receiver_get_rules,
-		offstate = "mesecons_receiver:receiver_off"
-	}}
-})
-
-
-minetest.register_node("mesecons_receiver:receiver_off", {
-	drawtype = "nodebox",
-	description = "You hacker you",
+},
+{
 	tiles = {
 		"receiver_top_off.png",
 		"receiver_bottom_off.png",
@@ -71,136 +54,111 @@ minetest.register_node("mesecons_receiver:receiver_off", {
 		"receiver_fb_off.png",
 		"receiver_fb_off.png",
 	},
+	mesecons = {conductor = {
+		state = mesecon.state.off,
+		rules = receiver_get_rules,
+		onstate = "mesecons_receiver:receiver_on"
+	}}
+},
+{
+	tiles = {
+		"receiver_top_on.png",
+		"receiver_bottom_on.png",
+		"receiver_lr_on.png",
+		"receiver_lr_on.png",
+		"receiver_fb_on.png",
+		"receiver_fb_on.png",
+	},
+	mesecons = {conductor = {
+		state = mesecon.state.on,
+		rules = receiver_get_rules,
+		offstate = "mesecons_receiver:receiver_off"
+	}}
+})
+
+mesecon.register_node("mesecons_receiver:receiver_up", {
+	drawtype = "nodebox",
 	paramtype = "light",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	walkable = false,
 	selection_box = {
              	type = "fixed",
-		fixed = { -3/16, -8/16, -8/16, 3/16, 3/16, 8/16 }
+		fixed = up_rcvboxes
 	},
 	node_box = {
 		type = "fixed",
-		fixed = rcvboxes
+		fixed = up_rcvboxes
 	},
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
+},
+{
+	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {
 		state = mesecon.state.off,
-		rules = receiver_get_rules,
-		onstate = "mesecons_receiver:receiver_on"
+		rules = {{x=1, y=0, z=0},
+			{x=-1, y=0, z=0},
+			{x=0,  y=0, z=1},
+			{x=0,  y=0, z=-1},
+			{x=0,  y=1, z=0},
+			{x=0,  y=2, z=0}},
+		onstate = "mesecons_receiver:receiver_up_on"
 	}}
-})
-
-minetest.register_node("mesecons_receiver:receiver_up_on", {
-	drawtype = "nodebox",
+},
+{
 	tiles = {"mesecons_wire_on.png"},
-	paramtype = "light",
-	sunlight_propagates = true,
-	walkable = false,
-	selection_box = {
-             	type = "fixed",
-		fixed = up_rcvboxes
-	},
-	node_box = {
-		type = "fixed",
-		fixed = up_rcvboxes
-	},
-	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
-	drop = "mesecons:wire_00000000_off",
 	mesecons = {conductor = {
 		state = mesecon.state.on,
 		rules = {{x=1, y=0, z=0},
 			{x=-1, y=0, z=0},
-			{x=0, y=0, z=1},
-			{x=0, y=0, z=-1},
-			{x=0, y=1, z=0},
-			{x=0, y=2, z=0}},
+			{x=0,  y=0, z=1},
+			{x=0,  y=0, z=-1},
+			{x=0,  y=1, z=0},
+			{x=0,  y=2, z=0}},
 		offstate = "mesecons_receiver:receiver_up_off"
 	}}
 })
 
-minetest.register_node("mesecons_receiver:receiver_up_off", {
+mesecon.register_node("mesecons_receiver:receiver_down", {
 	drawtype = "nodebox",
-	description = "You hacker you",
-	tiles = {"mesecons_wire_off.png"},
 	paramtype = "light",
+	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	walkable = false,
 	selection_box = {
              	type = "fixed",
-		fixed = up_rcvboxes
+		fixed = down_rcvboxes
 	},
 	node_box = {
 		type = "fixed",
-		fixed = up_rcvboxes
+		fixed = down_rcvboxes
 	},
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
+},
+{
+	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {
 		state = mesecon.state.off,
-		rules = {{x=1, y=0, z=0},
-			{x=-1, y=0, z=0},
+		rules = {{x=1,y=0, z=0},
+			{x=-1,y=0, z=0},
 			{x=0, y=0, z=1},
 			{x=0, y=0, z=-1},
-			{x=0, y=1, z=0},
-			{x=0, y=2, z=0}},
-		onstate = "mesecons_receiver:receiver_up_on"
+			{x=0, y=-2,z=0}},
+		onstate = "mesecons_receiver:receiver_down_on"
 	}}
-})
-
-minetest.register_node("mesecons_receiver:receiver_down_on", {
-	drawtype = "nodebox",
+},
+{
 	tiles = {"mesecons_wire_on.png"},
-	paramtype = "light",
-	sunlight_propagates = true,
-	walkable = false,
-	selection_box = {
-             	type = "fixed",
-		fixed = down_rcvboxes
-	},
-	node_box = {
-		type = "fixed",
-		fixed = down_rcvboxes
-	},
-	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
-	drop = "mesecons:wire_00000000_off",
 	mesecons = {conductor = {
 		state = mesecon.state.on,
 		rules = {{x=1,y=0, z=0},
 			{x=-1,y=0, z=0},
-			{x=0,y=0, z=1},
-			{x=0,y=0, z=-1},
-			{x=0,y=-2, z=0}},
+			{x=0, y=0, z=1},
+			{x=0, y=0, z=-1},
+			{x=0, y=-2,z=0}},
 		offstate = "mesecons_receiver:receiver_down_off"
-	}}
-})
-
-minetest.register_node("mesecons_receiver:receiver_down_off", {
-	drawtype = "nodebox",
-	description = "You hacker you",
-	tiles = {"mesecons_wire_off.png"},
-	paramtype = "light",
-	sunlight_propagates = true,
-	walkable = false,
-	selection_box = {
-             	type = "fixed",
-		fixed = down_rcvboxes
-	},
-	node_box = {
-		type = "fixed",
-		fixed = down_rcvboxes
-	},
-	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
-	drop = "mesecons:wire_00000000_off",
-	mesecons = {conductor = {
-		state = mesecon.state.off,
-		rules = {{x=1,y=0, z=0},
-			{x=-1,y=0, z=0},
-			{x=0,y=0, z=1},
-			{x=0,y=0, z=-1},
-			{x=0,y=-2, z=0}},
-		onstate = "mesecons_receiver:receiver_down_on"
 	}}
 })
 
@@ -287,7 +245,7 @@ minetest.register_on_placenode(function (pos, node)
 	end
 end)
 
-function mesecon.buttonlike_onrotate(pos,node,_,_,newparam2)
-	minetest.after(0,mesecon.receiver_remove,pos,node)
-	minetest.after(0,mesecon.receiver_place,pos)
+function mesecon.buttonlike_onrotate(pos, node, _, _, newparam2)
+	minetest.after(0, mesecon.receiver_remove, pos, node)
+	minetest.after(0, mesecon.receiver_place, pos)
 end

--- a/mesecons_receiver/init.lua
+++ b/mesecons_receiver/init.lua
@@ -6,13 +6,23 @@ local rcvboxes = {
 }
 
 local down_rcvboxes = {
-	{-8/16, -8/16, -8/16, 8/16, -7/16, 8/16},
-	{-1/16, -8/16, -1/16, 1/16, -24/16, 1/16},
+	{-6/16, -8/16, -6/16, 6/16, -7/16, 6/16}, -- Top plate
+	{-2/16, -6/16, -2/16, 2/16, -7/16, 2/16}, -- Bump
+	{-1/16, -8/16, -1/16, 1/16, -24/16, 1/16}, -- Wire through the block
+	{-1/16, -8/16, 6/16,  1/16, -7/16, 8/16}, -- Plate extension (North)
+	{-1/16, -8/16, -6/16, 1/16, -7/16, -8/16}, -- Plate extension (South)
+	{-8/16, -8/16, 1/16, -6/16, -7/16, -1/16}, -- Plate extension (West)
+	{6/16,  -8/16, 1/16,  8/16, -7/16, -1/16}, -- Plate extension (East)
 }
 
 local up_rcvboxes = {
-	{-8/16, -8/16, -8/16, 8/16, -7/16, 8/16},
-	{-1/16, -7/16, -1/16, 1/16, 24/16, 1/16},
+	{-6/16, -8/16, -6/16, 6/16, -7/16, 6/16}, -- Top plate
+	{-2/16, -6/16, -2/16, 2/16, -7/16, 2/16}, -- Bump
+	{-1/16, -6/16, -1/16, 1/16, 24/16, 1/16}, -- Wire through the block
+	{-1/16, -8/16, 6/16,  1/16, -7/16, 8/16}, -- Plate extension (North)
+	{-1/16, -8/16, -6/16, 1/16, -7/16, -8/16}, -- Plate extension (South)
+	{-8/16, -8/16, 1/16, -6/16, -7/16, -1/16}, -- Plate extension (West)
+	{6/16,  -8/16, 1/16,  8/16, -7/16, -1/16}, -- Plate extension (East)
 }
 
 local receiver_get_rules = function (node)
@@ -44,8 +54,8 @@ mesecon.register_node("mesecons_receiver:receiver", {
 	},
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
-},
-{
+	},
+	{
 	tiles = {
 		"receiver_top_off.png",
 		"receiver_bottom_off.png",
@@ -59,8 +69,8 @@ mesecon.register_node("mesecons_receiver:receiver", {
 		rules = receiver_get_rules,
 		onstate = "mesecons_receiver:receiver_on"
 	}}
-},
-{
+	},
+	{
 	tiles = {
 		"receiver_top_on.png",
 		"receiver_bottom_on.png",
@@ -92,8 +102,8 @@ mesecon.register_node("mesecons_receiver:receiver_up", {
 	},
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
-},
-{
+	},
+	{
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {
 		state = mesecon.state.off,
@@ -105,8 +115,8 @@ mesecon.register_node("mesecons_receiver:receiver_up", {
 			{x=0,  y=2, z=0}},
 		onstate = "mesecons_receiver:receiver_up_on"
 	}}
-},
-{
+	},
+	{
 	tiles = {"mesecons_wire_on.png"},
 	mesecons = {conductor = {
 		state = mesecon.state.on,
@@ -170,27 +180,27 @@ function mesecon.receiver_get_pos_from_rcpt(pos, param2)
 	if dir.x == 1 then
 		-- No action needed
 	elseif dir.z == -1 then
-		rules=mesecon.rotate_rules_left(rules)
+		rules = mesecon.rotate_rules_left(rules)
 	elseif dir.x == -1 then
-		rules=mesecon.rotate_rules_right(mesecon.rotate_rules_right(rules))
+		rules = mesecon.rotate_rules_right(mesecon.rotate_rules_right(rules))
 	elseif dir.z == 1 then
-		rules=mesecon.rotate_rules_right(rules)
+		rules = mesecon.rotate_rules_right(rules)
 	elseif dir.y == -1 then
-		rules=mesecon.rotate_rules_up(rules)
+		rules = mesecon.rotate_rules_up(rules)
 		rcvtype = "mesecons_receiver:receiver_up_off"
 	elseif dir.y == 1 then
-		rules=mesecon.rotate_rules_down(rules)
+		rules = mesecon.rotate_rules_down(rules)
 		rcvtype = "mesecons_receiver:receiver_down_off"
 	end
 	local np = {	x = pos.x + rules[1].x,
 			y = pos.y + rules[1].y,
 			z = pos.z + rules[1].z}
-	return np,rcvtype
+	return np, rcvtype
 end
 
 function mesecon.receiver_place(rcpt_pos)
 	local node = minetest.get_node(rcpt_pos)
-	local pos,rcvtype = mesecon.receiver_get_pos_from_rcpt(rcpt_pos, node.param2)
+	local pos, rcvtype = mesecon.receiver_get_pos_from_rcpt(rcpt_pos, node.param2)
 	local nn = minetest.get_node(pos)
 	local param2 = minetest.dir_to_facedir(minetest.facedir_to_dir(node.param2))
 

--- a/mesecons_receiver/init.lua
+++ b/mesecons_receiver/init.lua
@@ -1,8 +1,18 @@
-rcvboxes = {
+local rcvboxes = {
 	{ -3/16, -3/16, -8/16       , 3/16,  3/16  , -13/32       }, -- the smaller bump
 	{ -1/32, -1/32, -3/2        , 1/32,  1/32  , -1/2         }, -- the wire through the block
 	{ -2/32, -1/2 , -.5         , 2/32,  0     , -.5002+3/32  }, -- the vertical wire bit
 	{ -2/32, -1/2 , -7/16+0.002 , 2/32,  -14/32,  16/32+0.001 }  -- the horizontal wire
+}
+
+local down_rcvboxes = {
+	{-8/16, -8/16, -8/16, 8/16, -7/16, 8/16},
+	{-1/16, -8/16, -1/16, 1/16, -24/16, 1/16},
+}
+
+local up_rcvboxes = {
+	{-8/16, -8/16, -8/16, 8/16, -7/16, 8/16},
+	{-1/16, -7/16, -1/16, 1/16, 24/16, 1/16},
 }
 
 local receiver_get_rules = function (node)
@@ -49,6 +59,7 @@ minetest.register_node("mesecons_receiver:receiver_on", {
 	}}
 })
 
+
 minetest.register_node("mesecons_receiver:receiver_off", {
 	drawtype = "nodebox",
 	description = "You hacker you",
@@ -81,30 +92,153 @@ minetest.register_node("mesecons_receiver:receiver_off", {
 	}}
 })
 
+minetest.register_node("mesecons_receiver:receiver_up_on", {
+	drawtype = "nodebox",
+	tiles = {"mesecons_wire_on.png"},
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	selection_box = {
+             	type = "fixed",
+		fixed = up_rcvboxes
+	},
+	node_box = {
+		type = "fixed",
+		fixed = up_rcvboxes
+	},
+	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
+	drop = "mesecons:wire_00000000_off",
+	mesecons = {conductor = {
+		state = mesecon.state.on,
+		rules = {{x=1, y=0, z=0},
+			{x=-1, y=0, z=0},
+			{x=0, y=0, z=1},
+			{x=0, y=0, z=-1},
+			{x=0, y=1, z=0},
+			{x=0, y=2, z=0}},
+		offstate = "mesecons_receiver:receiver_up_off"
+	}}
+})
+
+minetest.register_node("mesecons_receiver:receiver_up_off", {
+	drawtype = "nodebox",
+	description = "You hacker you",
+	tiles = {"mesecons_wire_off.png"},
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	selection_box = {
+             	type = "fixed",
+		fixed = up_rcvboxes
+	},
+	node_box = {
+		type = "fixed",
+		fixed = up_rcvboxes
+	},
+	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
+	drop = "mesecons:wire_00000000_off",
+	mesecons = {conductor = {
+		state = mesecon.state.off,
+		rules = {{x=1, y=0, z=0},
+			{x=-1, y=0, z=0},
+			{x=0, y=0, z=1},
+			{x=0, y=0, z=-1},
+			{x=0, y=1, z=0},
+			{x=0, y=2, z=0}},
+		onstate = "mesecons_receiver:receiver_up_on"
+	}}
+})
+
+minetest.register_node("mesecons_receiver:receiver_down_on", {
+	drawtype = "nodebox",
+	tiles = {"mesecons_wire_on.png"},
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	selection_box = {
+             	type = "fixed",
+		fixed = down_rcvboxes
+	},
+	node_box = {
+		type = "fixed",
+		fixed = down_rcvboxes
+	},
+	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
+	drop = "mesecons:wire_00000000_off",
+	mesecons = {conductor = {
+		state = mesecon.state.on,
+		rules = {{x=1,y=0, z=0},
+			{x=-1,y=0, z=0},
+			{x=0,y=0, z=1},
+			{x=0,y=0, z=-1},
+			{x=0,y=-2, z=0}},
+		offstate = "mesecons_receiver:receiver_down_off"
+	}}
+})
+
+minetest.register_node("mesecons_receiver:receiver_down_off", {
+	drawtype = "nodebox",
+	description = "You hacker you",
+	tiles = {"mesecons_wire_off.png"},
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	selection_box = {
+             	type = "fixed",
+		fixed = down_rcvboxes
+	},
+	node_box = {
+		type = "fixed",
+		fixed = down_rcvboxes
+	},
+	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
+	drop = "mesecons:wire_00000000_off",
+	mesecons = {conductor = {
+		state = mesecon.state.off,
+		rules = {{x=1,y=0, z=0},
+			{x=-1,y=0, z=0},
+			{x=0,y=0, z=1},
+			{x=0,y=0, z=-1},
+			{x=0,y=-2, z=0}},
+		onstate = "mesecons_receiver:receiver_down_on"
+	}}
+})
+
 function mesecon.receiver_get_pos_from_rcpt(pos, param2)
 	local rules = {{x = 2,  y = 0, z = 0}}
 	if param2 == nil then param2 = minetest.get_node(pos).param2 end
-	if param2 == 2 then
-		rules = mesecon.rotate_rules_left(rules)
-	elseif param2 == 3 then
-		rules = mesecon.rotate_rules_right(mesecon.rotate_rules_right(rules))
-	elseif param2 == 0 then
-		rules = mesecon.rotate_rules_right(rules)
+	local rcvtype = "mesecons_receiver:receiver_off"
+	local dir = minetest.facedir_to_dir(param2)
+	if dir.x == 1 then
+		-- No action needed
+	elseif dir.z == -1 then
+		rules=mesecon.rotate_rules_left(rules)
+	elseif dir.x == -1 then
+		rules=mesecon.rotate_rules_right(mesecon.rotate_rules_right(rules))
+	elseif dir.z == 1 then
+		rules=mesecon.rotate_rules_right(rules)
+	elseif dir.y == -1 then
+		rules=mesecon.rotate_rules_up(rules)
+		rcvtype = "mesecons_receiver:receiver_up_off"
+	elseif dir.y == 1 then
+		rules=mesecon.rotate_rules_down(rules)
+		rcvtype = "mesecons_receiver:receiver_down_off"
 	end
 	local np = {	x = pos.x + rules[1].x,
 			y = pos.y + rules[1].y,
 			z = pos.z + rules[1].z}
-	return np
+	return np,rcvtype
 end
 
 function mesecon.receiver_place(rcpt_pos)
 	local node = minetest.get_node(rcpt_pos)
-	local pos = mesecon.receiver_get_pos_from_rcpt(rcpt_pos, node.param2)
+	local pos,rcvtype = mesecon.receiver_get_pos_from_rcpt(rcpt_pos, node.param2)
 	local nn = minetest.get_node(pos)
+	local param2 = minetest.dir_to_facedir(minetest.facedir_to_dir(node.param2))
 
 	if string.find(nn.name, "mesecons:wire_") ~= nil then
 		minetest.dig_node(pos)
-		minetest.set_node(pos, {name = "mesecons_receiver:receiver_off", param2 = node.param2})
+		minetest.set_node(pos, {name = rcvtype, param2 = param2})
 		mesecon.on_placenode(pos, nn)
 	end
 end
@@ -134,10 +268,12 @@ end)
 
 minetest.register_on_placenode(function (pos, node)
 	if string.find(node.name, "mesecons:wire_") ~=nil then
-		local rules = {	{x = 2,  y = 0, z = 0},
-				{x =-2,  y = 0, z = 0},
-				{x = 0,  y = 0, z = 2},
-				{x = 0,  y = 0, z =-2}}
+		local rules = {	{x = 2,  y = 0,  z = 0},
+				{x =-2,  y = 0,  z = 0},
+				{x = 0,  y = 0,  z = 2},
+				{x = 0,  y = 0,  z =-2},
+				{x = 0,  y = 2,  z = 0},
+				{x = 0,  y = -2, z = 0}}
 		local i = 1
 		while rules[i] ~= nil do
 			local np = {	x = pos.x + rules[i].x,
@@ -150,3 +286,8 @@ minetest.register_on_placenode(function (pos, node)
 		end
 	end
 end)
+
+function mesecon.buttonlike_onrotate(pos,node,_,_,newparam2)
+	minetest.after(0,mesecon.receiver_remove,pos,node)
+	minetest.after(0,mesecon.receiver_place,pos)
+end

--- a/mesecons_walllever/init.lua
+++ b/mesecons_walllever/init.lua
@@ -31,6 +31,7 @@ mesecon.register_node("mesecons_walllever:wall_lever", {
 		"jeija_wall_lever_back_edges.png"
 	},
 	mesh="jeija_wall_lever_off.obj",
+	on_rotate = mesecon.buttonlike_onrotate,
 	mesecons = {receptor = {
 		rules = mesecon.rules.buttonlike_get,
 		state = mesecon.state.off
@@ -44,6 +45,7 @@ mesecon.register_node("mesecons_walllever:wall_lever", {
 		"jeija_wall_lever_back_edges.png"
 	},
 	mesh="jeija_wall_lever_on.obj",
+	on_rotate = false,
 	mesecons = {receptor = {
 		rules = mesecon.rules.buttonlike_get,
 		state = mesecon.state.on


### PR DESCRIPTION
This fixes #298 by registering new "receivers" that point up/down (made to look like vertical mesecons). They are used whenever a button or "wall lever" (they're not just for walls any more :) is rotated such that it is mounted to the floor or ceiling. You can also have them upside-down on the wall and all that fun stuff, and the receivers are still right-side up for that.

As an added (and somewhat beneficial) side effect, floor-mounted buttons and levers work with vertical mesecons as well, in the same way as pressure plates.