### PR TITLE
Add protection testing to the Piston and Movestones.

### DIFF
--- a/mesecons_movestones/init.lua
+++ b/mesecons_movestones/init.lua
@@ -73,7 +73,7 @@ function mesecon.register_movestone(name, def, is_sticky)
 		-- ### Step 1: Push nodes in front ###
 		local maxpush = mesecon.setting("movestone_max_push", 50)
 		local maxpull = mesecon.setting("movestone_max_pull", 50)
-		local success, stack, oldstack = mesecon.mvps_push(frontpos, direction, maxpush)
+		local success, stack, oldstack = mesecon.mvps_push(pos, frontpos, direction, maxpush)
 		if success then
 			mesecon.mvps_process_stack(stack)
 			mesecon.mvps_move_objects(frontpos, direction, oldstack)
@@ -85,15 +85,18 @@ function mesecon.register_movestone(name, def, is_sticky)
 
 		-- ### Step 2: Move the movestone ###
 		local node = minetest.get_node(pos)
+		local owner = minetest.get_meta(pos):get_string("owner")
 		minetest.set_node(frontpos, node)
 		minetest.remove_node(pos)
 		mesecon.on_dignode(pos, node)
 		mesecon.on_placenode(frontpos, node)
+		minetest.get_meta(frontpos):set_string("owner", owner)
+		minetest.get_meta(frontpos):set_string("infotext", "Movestone (owned by "..owner..")")
 		minetest.after(timer_interval, movestone_move, frontpos)
 
 		-- ### Step 3: If sticky, pull stack behind ###
 		if is_sticky then
-			mesecon.mvps_pull_all(backpos, direction, maxpull)
+			mesecon.mvps_pull_all(pos, backpos, direction, maxpull)
 		end
 	end
 
@@ -123,7 +126,11 @@ mesecon.register_movestone("mesecons_movestones:movestone", {
 	tiles = {"jeija_movestone_side.png", "jeija_movestone_side.png", "jeija_movestone_side.png", "jeija_movestone_side.png", "jeija_movestone_arrows.png", "jeija_movestone_arrows.png"},
 	groups = {cracky=3},
     	description="Movestone",
-	sounds = default.node_sound_stone_defaults()
+	sounds = default.node_sound_stone_defaults(),
+	after_place_node = function(pos, player)
+		minetest.get_meta(pos):set_string("owner", player:get_player_name())
+		minetest.get_meta(pos):set_string("infotext", "Movestone (owned by "..player:get_player_name()..")")
+	end,
 }, false)
 
 minetest.register_craft({
@@ -142,6 +149,10 @@ mesecon.register_movestone("mesecons_movestones:sticky_movestone", {
 	groups = {cracky=3},
     	description="Sticky Movestone",
 	sounds = default.node_sound_stone_defaults(),
+	after_place_node = function(pos, player)
+		minetest.get_meta(pos):set_string("owner", player:get_player_name())
+		minetest.get_meta(pos):set_string("infotext", "Movestone (owned by "..player:get_player_name()..")")
+	end,
 }, true)
 
 minetest.register_craft({

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -135,29 +135,52 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 	return nodes
 end
 
-function mesecon.mvps_push(pos, dir, maximum)
-	return mesecon.mvps_push_or_pull(pos, dir, dir, maximum)
+function mesecon.mvps_push(from, pos, dir, maximum)
+	return mesecon.mvps_push_or_pull(from, false, pos, dir, dir, maximum)
 end
 
-function mesecon.mvps_pull_all(pos, dir, maximum)
-	return mesecon.mvps_push_or_pull(pos, vector.multiply(dir, -1), dir, maximum, true)
+function mesecon.mvps_pull_all(from, pos, dir, maximum)
+	return mesecon.mvps_push_or_pull(from, true, pos, vector.multiply(dir, -1), dir, maximum, true)
 end
 
-function mesecon.mvps_pull_single(pos, dir, maximum)
-	return mesecon.mvps_push_or_pull(pos, vector.multiply(dir, -1), dir, maximum)
+function mesecon.mvps_pull_single(from, pos, dir, maximum)
+	return mesecon.mvps_push_or_pull(from, true, pos, vector.multiply(dir, -1), dir, maximum)
 end
 
 -- pos: pos of mvps; stackdir: direction of building the stack
 -- movedir: direction of actual movement
 -- maximum: maximum nodes to be pushed
 -- all_pull_sticky: All nodes are sticky in the direction that they are pulled from
-function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sticky)
-	local nodes = mesecon.mvps_get_stack(pos, movedir, maximum, all_pull_sticky)
-
-	if not nodes then return end
+function mesecon.mvps_push_or_pull(from, ispulling, pos, stackdir, movedir, maximum, all_pull_sticky)
+	local has_meta = minetest.get_meta(from):to_table()
+	local owner = minetest.get_meta(from):get_string("owner")
+	local tnodes = mesecon.mvps_get_stack(pos, movedir, maximum, all_pull_sticky)
+	if not tnodes then return end
 	-- determine if one of the nodes blocks the push / pull
-	for id, n in ipairs(nodes) do
+	local nodes = {}
+	for id, n in ipairs(tnodes) do
+		if not has_meta or minetest.is_protected(n.pos, owner) then
+			if ispulling then
+				break
+			else
+				return
+			end
+		end
 		if mesecon.is_mvps_stopper(n.node, movedir, nodes, id) then
+			if ispulling then
+				break
+			else
+				return
+			end
+		end
+		nodes[id] = n
+	end
+
+	-- check nodes
+	for _, n in ipairs(nodes) do
+		local np = vector.add(n.pos, movedir)
+
+		if not has_meta or minetest.is_protected(np, owner) then
 			return
 		end
 	end

--- a/mesecons_pistons/init.lua
+++ b/mesecons_pistons/init.lua
@@ -80,7 +80,7 @@ local piston_on = function(pos, node)
 	local dir = piston_get_direction(pistonspec.dir, node)
 	local np = vector.add(pos, dir)
 	local maxpush = mesecon.setting("piston_max_push", 15)
-	local success, stack, oldstack = mesecon.mvps_push(np, dir, maxpush)
+	local success, stack, oldstack = mesecon.mvps_push(pos, np, dir, maxpush)
 	if success then
 		minetest.set_node(pos, {param2 = node.param2, name = pistonspec.onname})
 		minetest.set_node(np,  {param2 = node.param2, name = pistonspec.pusher})
@@ -103,7 +103,7 @@ local piston_off = function(pos, node)
 		local maxpull = mesecon.setting("piston_max_pull", 15)
 		local dir = piston_get_direction(pistonspec.dir, node)
 		local pullpos = vector.add(pos, vector.multiply(dir, 2))
-		local stack = mesecon.mvps_pull_single(pullpos, vector.multiply(dir, -1), maxpull)
+		local stack = mesecon.mvps_pull_single(pos, pullpos, vector.multiply(dir, -1), maxpull)
 		mesecon.mvps_process_stack(pos, dir, stack)
 	end
 end
@@ -111,6 +111,9 @@ end
 local piston_orientate = function(pos, placer)
 	-- not placed by player
 	if not placer then return end
+
+	minetest.get_meta(pos):set_string("owner", placer:get_player_name())
+	minetest.get_meta(pos):set_string("infotext", "Piston (owned by "..placer:get_player_name()..")")
 
 	-- placer pitch in degrees
 	local pitch = placer:get_look_pitch() * (180 / math.pi)


### PR DESCRIPTION
This adds protection checking to pistons and movestones. If a protected node is encountered when pushing, the action will fail. If it is encountered while pulling, only the stack up to that point will be pulled. Nodes placed before this change was implemented will continue to act as before.

Fixes #281 