### PR TITLE
Spell-check and clarify all item names

### DIFF
--- a/mesecons_extrawires/vertical.lua
+++ b/mesecons_extrawires/vertical.lua
@@ -77,7 +77,7 @@ end
 
 -- Vertical wire
 mesecon.register_node("mesecons_extrawires:vertical", {
-	description = "Vertical mesecon",
+	description = "Vertical Mesecon",
 	drawtype = "nodebox",
 	walkable = false,
 	paramtype = "light",

--- a/mesecons_gates/doc/and/description.html
+++ b/mesecons_gates/doc/and/description.html
@@ -1,1 +1,1 @@
-And gates power their output if both inputs (from left and right) are powered.
+AND gates power their output if both inputs (from left and right) are powered.

--- a/mesecons_gates/doc/diode/description.html
+++ b/mesecons_gates/doc/diode/description.html
@@ -1,1 +1,1 @@
-Mesecon diodes, just like real ones, only transfer power (signals) in one direction only.
+Diodes only transfer power (signals) to one direction.

--- a/mesecons_gates/doc/diode/description.html
+++ b/mesecons_gates/doc/diode/description.html
@@ -1,1 +1,1 @@
-Diodes only transfer power (signals) to one direction.
+Diodes conduct signals in one direction only.

--- a/mesecons_gates/doc/nand/description.html
+++ b/mesecons_gates/doc/nand/description.html
@@ -1,1 +1,1 @@
-Nand gates do not power their output if both inputs (from left and right) are powered, but power it in every other case.
+NAND gates do not power their output if both inputs (from left and right) are powered, but power it in every other case.

--- a/mesecons_gates/doc/nor/description.html
+++ b/mesecons_gates/doc/nor/description.html
@@ -1,1 +1,1 @@
-Nor gates only power their output if none of their two inputs is powered. They are basically or gates with a not gate at their output.
+NOR gates only power their output if none of their two inputs is powered. They are basically OR gates with a NOT gate at their output.

--- a/mesecons_gates/doc/not/description.html
+++ b/mesecons_gates/doc/not/description.html
@@ -1,1 +1,1 @@
-Not gates invert signals, just like a mesecon torch does, but faster. The input is at the opposite side of the output.
+NOT gates invert signals, just like a mesecon torch does, but faster. The input is at the opposite side of the output.

--- a/mesecons_gates/doc/or/description.html
+++ b/mesecons_gates/doc/or/description.html
@@ -1,1 +1,1 @@
-Or gates power their output if either of their inputs (or both) are powered. You could basically get the same behaviour with two diodes, but or gates save some space.
+OR gates power their output if either of their inputs (or both) are powered. You could basically get the same behaviour with two diodes, but OR gates save some space.

--- a/mesecons_gates/init.lua
+++ b/mesecons_gates/init.lua
@@ -57,9 +57,7 @@ end
 local function register_gate(name, inputnumber, assess, recipe, description)
 	local get_inputrules = inputnumber == 2 and gate_get_input_rules_twoinputs or
 		gate_get_input_rules_oneinput
-	if not description then
-		description = "Logic Gate: "..name
-	end
+	description = "Logic Gate: "..name
 
 	local basename = "mesecons_gates:"..name
 	mesecon.register_node(basename, {

--- a/mesecons_gates/init.lua
+++ b/mesecons_gates/init.lua
@@ -54,10 +54,12 @@ local function update_gate(pos, node, link, newstate)
 	end
 end
 
-local function register_gate(name, inputnumber, assess, recipe)
+local function register_gate(name, inputnumber, assess, recipe, description)
 	local get_inputrules = inputnumber == 2 and gate_get_input_rules_twoinputs or
 		gate_get_input_rules_oneinput
-	local description = "Mesecons Logic Gate: "..name
+	if not description then
+		description = "Logic Gate: "..name
+	end
 
 	local basename = "mesecons_gates:"..name
 	mesecon.register_node(basename, {
@@ -103,32 +105,39 @@ local function register_gate(name, inputnumber, assess, recipe)
 end
 
 register_gate("diode", 1, function (input) return input end,
-	{{"mesecons:mesecon", "mesecons_torch:mesecon_torch_on", "mesecons_torch:mesecon_torch_on"}})
+	{{"mesecons:mesecon", "mesecons_torch:mesecon_torch_on", "mesecons_torch:mesecon_torch_on"}},
+	"Diode")
 
 register_gate("not", 1, function (input) return not input end,
-	{{"mesecons:mesecon", "mesecons_torch:mesecon_torch_on", "mesecons:mesecon"}})
+	{{"mesecons:mesecon", "mesecons_torch:mesecon_torch_on", "mesecons:mesecon"}},
+	"NOT Gate")
 
 register_gate("and", 2, function (val1, val2) return val1 and val2 end,
 	{{"mesecons:mesecon", "", ""},
 	 {"", "mesecons_materials:silicon", "mesecons:mesecon"},
-	 {"mesecons:mesecon", "", ""}})
+	 {"mesecons:mesecon", "", ""}},
+	"AND Gate")
 
 register_gate("nand", 2, function (val1, val2) return not (val1 and val2) end,
 	{{"mesecons:mesecon", "", ""},
 	 {"", "mesecons_materials:silicon", "mesecons_torch:mesecon_torch_on"},
-	 {"mesecons:mesecon", "", ""}})
+	 {"mesecons:mesecon", "", ""}},
+	"NAND Gate")
 
 register_gate("xor", 2, function (val1, val2) return (val1 or val2) and not (val1 and val2) end,
 	{{"mesecons:mesecon", "", ""},
 	 {"", "mesecons_materials:silicon", "mesecons_materials:silicon"},
-	 {"mesecons:mesecon", "", ""}})
+	 {"mesecons:mesecon", "", ""}},
+	"XOR Gate")
 
 register_gate("nor", 2, function (val1, val2) return not (val1 or val2) end,
 	{{"mesecons:mesecon", "", ""},
 	 {"", "mesecons:mesecon", "mesecons_torch:mesecon_torch_on"},
-	 {"mesecons:mesecon", "", ""}})
+	 {"mesecons:mesecon", "", ""}},
+	"NOR Gate")
 
 register_gate("or", 2, function (val1, val2) return (val1 or val2) end,
 	{{"mesecons:mesecon", "", ""},
 	 {"", "mesecons:mesecon", "mesecons:mesecon"},
-	 {"mesecons:mesecon", "", ""}})
+	 {"mesecons:mesecon", "", ""}},
+	"OR Gate")

--- a/mesecons_insulated/init.lua
+++ b/mesecons_insulated/init.lua
@@ -9,7 +9,7 @@ end
 
 minetest.register_node("mesecons_insulated:insulated_on", {
 	drawtype = "nodebox",
-	description = "Insulated Mesecon",
+	description = "Straight Insulated Mesecon",
 	tiles = {
 		"jeija_insulated_wire_sides_on.png",
 		"jeija_insulated_wire_sides_on.png",
@@ -41,7 +41,7 @@ minetest.register_node("mesecons_insulated:insulated_on", {
 
 minetest.register_node("mesecons_insulated:insulated_off", {
 	drawtype = "nodebox",
-	description = "Insulated Mesecon",
+	description = "Insulated Straight Mesecon",
 	tiles = {
 		"jeija_insulated_wire_sides_off.png",
 		"jeija_insulated_wire_sides_off.png",

--- a/mesecons_insulated/init.lua
+++ b/mesecons_insulated/init.lua
@@ -41,7 +41,7 @@ minetest.register_node("mesecons_insulated:insulated_on", {
 
 minetest.register_node("mesecons_insulated:insulated_off", {
 	drawtype = "nodebox",
-	description = "Insulated Straight Mesecon",
+	description = "Straight Insulated Mesecon",
 	tiles = {
 		"jeija_insulated_wire_sides_off.png",
 		"jeija_insulated_wire_sides_off.png",

--- a/mesecons_lamp/doc/lamp/description.html
+++ b/mesecons_lamp/doc/lamp/description.html
@@ -1,1 +1,1 @@
-Lamps are effectors that if powered emit light.
+Mesecon lamps are effectors that if powered emit light.

--- a/mesecons_lamp/init.lua
+++ b/mesecons_lamp/init.lua
@@ -42,7 +42,7 @@ minetest.register_node("mesecons_lamp:lamp_off", {
 	node_box = mesecon_lamp_box,
 	selection_box = mesecon_lamp_box,
 	groups = {dig_immediate=3, mesecon_receptor_off = 1, mesecon_effector_off = 1},
-    	description="Meselamp",
+    	description="Attached Lamp",
 	sounds = default.node_sound_glass_defaults(),
 	mesecons = {effector = {
 		action_on = function (pos, node)

--- a/mesecons_lamp/init.lua
+++ b/mesecons_lamp/init.lua
@@ -42,7 +42,7 @@ minetest.register_node("mesecons_lamp:lamp_off", {
 	node_box = mesecon_lamp_box,
 	selection_box = mesecon_lamp_box,
 	groups = {dig_immediate=3, mesecon_receptor_off = 1, mesecon_effector_off = 1},
-    	description="Attached Lamp",
+	description="Mesecon Lamp",
 	sounds = default.node_sound_glass_defaults(),
 	mesecons = {effector = {
 		action_on = function (pos, node)

--- a/mesecons_lightstone/init.lua
+++ b/mesecons_lightstone/init.lua
@@ -16,7 +16,7 @@ local lightstone_rules = {
 
 function mesecon.lightstone_add(name, base_item, texture_off, texture_on, desc)
 	if not desc then
-		desc = name .. " Lighttone"
+		desc = name .. " Lightstone"
 	end
 	minetest.register_node("mesecons_lightstone:lightstone_" .. name .. "_off", {
 		tiles = {texture_off},

--- a/mesecons_lightstone/init.lua
+++ b/mesecons_lightstone/init.lua
@@ -14,11 +14,14 @@ local lightstone_rules = {
 	{x=0,  y=-1, z=0},
 }
 
-function mesecon.lightstone_add(name, base_item, texture_off, texture_on)
+function mesecon.lightstone_add(name, base_item, texture_off, texture_on, desc)
+	if not desc then
+		desc = name .. " Lighttone"
+	end
 	minetest.register_node("mesecons_lightstone:lightstone_" .. name .. "_off", {
 		tiles = {texture_off},
 		groups = {cracky=2, mesecon_effector_off = 1, mesecon = 2},
-		description=name.." Lightstone",
+		description = desc,
 		sounds = default.node_sound_stone_defaults(),
 		mesecons = {effector = {
 			rules = lightstone_rules,
@@ -52,9 +55,9 @@ function mesecon.lightstone_add(name, base_item, texture_off, texture_on)
 end
 
 
-mesecon.lightstone_add("red", "dye:red", "jeija_lightstone_red_off.png", "jeija_lightstone_red_on.png")
-mesecon.lightstone_add("green", "dye:green", "jeija_lightstone_green_off.png", "jeija_lightstone_green_on.png")
-mesecon.lightstone_add("blue", "dye:blue", "jeija_lightstone_blue_off.png", "jeija_lightstone_blue_on.png")
-mesecon.lightstone_add("gray", "dye:grey", "jeija_lightstone_gray_off.png", "jeija_lightstone_gray_on.png")
-mesecon.lightstone_add("darkgray", "dye:dark_grey", "jeija_lightstone_darkgray_off.png", "jeija_lightstone_darkgray_on.png")
-mesecon.lightstone_add("yellow", "dye:yellow", "jeija_lightstone_yellow_off.png", "jeija_lightstone_yellow_on.png")
+mesecon.lightstone_add("red", "dye:red", "jeija_lightstone_red_off.png", "jeija_lightstone_red_on.png", "Red Lightstone")
+mesecon.lightstone_add("green", "dye:green", "jeija_lightstone_green_off.png", "jeija_lightstone_green_on.png", "Green Lightstone")
+mesecon.lightstone_add("blue", "dye:blue", "jeija_lightstone_blue_off.png", "jeija_lightstone_blue_on.png", "Blue Lightstone")
+mesecon.lightstone_add("gray", "dye:grey", "jeija_lightstone_gray_off.png", "jeija_lightstone_gray_on.png", "Grey Lightstone")
+mesecon.lightstone_add("darkgray", "dye:dark_grey", "jeija_lightstone_darkgray_off.png", "jeija_lightstone_darkgray_on.png", "Dark Grey Lightstone")
+mesecon.lightstone_add("yellow", "dye:yellow", "jeija_lightstone_yellow_off.png", "jeija_lightstone_yellow_on.png", "Yellow Lightstone")

--- a/mesecons_luacontroller/doc/luacontroller/description.html
+++ b/mesecons_luacontroller/doc/luacontroller/description.html
@@ -1,4 +1,4 @@
-The Lua controller is an advanced programmable component.
+The Luacontroller is an advanced programmable component.
 You can simply code it in the language Mesecons uses itself: Lua!
 All the code runs in a sandbox, so it's completely safe (but I won't guarantee that for absolute certainty!).
 

--- a/mesecons_luacontroller/doc/luacontroller/description.html
+++ b/mesecons_luacontroller/doc/luacontroller/description.html
@@ -1,5 +1,5 @@
-The luacontroller is an advanced programmable component.
-You can simply code it in the language mesecons uses itself: Lua!
+The Lua controller is an advanced programmable component.
+You can simply code it in the language Mesecons uses itself: Lua!
 All the code runs in a sandbox, so it's completely safe (but I won't guarantee that for absolute certainty!).
 
 <a href="http://mesecons.net/luacontroller/">Documentation is available here!</a>

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -12,7 +12,7 @@
 -- ports = get_real_port_states(pos): gets if inputs are powered from outside
 -- newport = merge_port_states(state1, state2): just does result = state1 or state2 for every port
 -- set_port(pos, rule, state): activates/deactivates the mesecons according to the port states
--- set_port_states(pos, ports): Applies new port states to a LuaController at pos
+-- set_port_states(pos, ports): Applies new port states to a Luacontroller at pos
 -- run(pos): runs the code in the controller at pos
 -- reset_meta(pos, code, errmsg): performs a software-reset, installs new code and prints error messages
 -- resetn(pos): performs a hardware reset, turns off all ports
@@ -219,7 +219,7 @@ end
 local function safe_string_find(...)
 	if (select(4, ...)) ~= true then
 		debug.sethook() -- Clear hook
-		error("string.find: 'plain' (fourth parameter) must always be true in a LuaController")
+		error("string.find: 'plain' (fourth parameter) must always be true in a Luacontroller")
 	end
 
 	return string.find(...)
@@ -232,7 +232,7 @@ local function remove_functions(x)
 	end
 
 	-- Make sure to not serialize the same table multiple times, otherwise
-	-- writing mem.test = mem in the LuaController will lead to infinite recursion
+	-- writing mem.test = mem in the Luacontroller will lead to infinite recursion
 	local seen = {}
 
 	local function rfuncs(x)
@@ -308,8 +308,8 @@ local function create_environment(pos, mem, event)
 	for k, v in pairs(vports) do vports_copy[k] = v end
 	local rports = get_real_port_states(pos)
 
-	-- Create new library tables on each call to prevent one LuaController
-	-- from breaking a library and messing up other LuaControllers.
+	-- Create new library tables on each call to prevent one Luacontroller
+	-- from breaking a library and messing up other Luacontrollers.
 	local env = {
 		pin = merge_port_states(vports, rports),
 		port = vports_copy,
@@ -595,7 +595,7 @@ for d = 0, 1 do
 	}
 
 	minetest.register_node(node_name, {
-		description = "Lua Controller",
+		description = "Luacontroller",
 		drawtype = "nodebox",
 		tiles = {
 			top,
@@ -636,7 +636,7 @@ end
 end
 
 ------------------------------
--- Overheated LuaController --
+-- Overheated Luacontroller --
 ------------------------------
 
 minetest.register_node(BASENAME .. "_burnt", {

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -595,7 +595,7 @@ for d = 0, 1 do
 	}
 
 	minetest.register_node(node_name, {
-		description = "LuaController",
+		description = "Lua Controller",
 		drawtype = "nodebox",
 		tiles = {
 			top,

--- a/mesecons_stickyblocks/init.lua
+++ b/mesecons_stickyblocks/init.lua
@@ -3,7 +3,7 @@
 
 -- All sides sticky block
 minetest.register_node("mesecons_stickyblocks:sticky_block_all", {
-	description = "All-sides sticky block",
+	description = "All-Sides Sticky Block",
 	tiles = {"default_grass.png^default_footprint.png"},
 	groups = {dig_immediate=2},
 	mvps_sticky = function (pos, node)


### PR DESCRIPTION
This PR changes the item names (more specifically: `description` aka tooltip) to make them more consistent and logical.

* Meselamp was renamed because Minetest Game has an item called “Mese Lamp”
* Logic gates and diodes have simplified names
* Capitalization fixes